### PR TITLE
Add support for blacklisting, systemd, and squashfs

### DIFF
--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -768,10 +768,13 @@ class CVMFSManager(object):
     # Now process the sub-catalogs
     for sub_path, sub_hash in cat_obj.children():
       # Skip blacklisted sub-catalogs
+      blacklisted = False
       for entry in self.__blacklist_paths:
         if fnmatch.fnmatch(sub_path, entry):
           self.__config.get_log().debug("Skipping sub-catalog '%s' based on blacklist '%s'.", sub_path, entry)
-          continue
+          blacklisted = True
+          break
+      if blacklisted: continue
       sub_total, sub_updated = self.__update_cats(sub_path, sub_hash)
       num_total += sub_total
       num_updated += sub_updated

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -478,10 +478,14 @@ class CVMFSCatalog(object):
         Note: This function is not recursive.
         Returns: A list of (path, hash) tuples, one for each sub-cat.
     """
-    cur = self.__db_conn.cursor()
-    cur.execute("SELECT path, sha1 FROM nested_catalogs")
-    res = cur.fetchall()
-    cur.close()
+    try:
+      cur = self.__db_conn.cursor()
+      cur.execute("SELECT path, sha1 FROM nested_catalogs")
+      res = cur.fetchall()
+      cur.close()
+    except sqlite3.OperationalError, oe:
+      self.__config.get_log().error("Failed to query nested catalog: %s", str(oe))
+      return []
     return res
 
   def is_done(self):

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -746,6 +746,12 @@ class CVMFSManager(object):
     # Get the old hash of the catalog
     num_total = 1
     num_updated = 0
+    # Skip blacklisted sub-catalogs
+    for entry in self.__blacklist_paths:
+      if fnmatch.fnmatch(cat_path, entry):
+        self.__config.get_log().debug("Skipping '%s' based on blacklist '%s'.", sub_path, entry)
+        return num_total, num_updated
+
     old_hash = self.__cat_hash(cat_path)
     cat_obj = CVMFSCatalog(self.__config, cat_path, old_hash)
     # If the hash has changed, update the catalog
@@ -764,7 +770,7 @@ class CVMFSManager(object):
       # Skip blacklisted sub-catalogs
       for entry in self.__blacklist_paths:
         if fnmatch.fnmatch(sub_path, entry):
-          self.__config.get_log().debug("Skipping '%s' based on blacklist '%s'.", sub_path, entry)
+          self.__config.get_log().debug("Skipping sub-catalog '%s' based on blacklist '%s'.", sub_path, entry)
           continue
       sub_total, sub_updated = self.__update_cats(sub_path, sub_hash)
       num_total += sub_total

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -764,6 +764,7 @@ class CVMFSManager(object):
       # Skip blacklisted sub-catalogs
       for entry in self.__blacklist_paths:
         if fnmatch.fnmatch(sub_path, entry):
+          self.__config.get_log().debug("Skipping '%s' based on blacklist '%s'.", sub_path, entry)
           continue
       sub_total, sub_updated = self.__update_cats(sub_path, sub_hash)
       num_total += sub_total

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -1023,6 +1023,7 @@ class UNCVMFSConfig(object):
     self.__log = logging.getLogger("UNCVMFSLib")
     self.__db_path = None
     self.__data_path = None
+    self.__squashfs_path = None
     self.__store_path = None
     self.__proxy = ""
     self.__urls = None
@@ -1051,6 +1052,9 @@ class UNCVMFSConfig(object):
       elif opt == 'data_path':
         tmp_path = conf.get(repo, "data_path")
         self.__data_path = os.path.normpath(tmp_path)
+      elif opt == 'squashfs_path':
+        tmp_path = conf.get(repo, "squashfs_path")
+        self.__squashfs_path = os.path.normpath(tmp_path)
       elif opt == 'store_path':
         tmp_path = conf.get(repo, "store_path")
         self.__store_path = os.path.normpath(tmp_path)
@@ -1126,6 +1130,11 @@ class UNCVMFSConfig(object):
         (db_path, data_path, store_path)
     """
     return (self.__db_path, self.__data_path, self.__store_path)
+
+  def get_squashfs_path(self):
+    """ Returns the desired output path for the squashfs file.
+    """
+    return self.__squashfs_path
 
   def get_proxy(self):
     """ Returns the proxy server the user specified. """

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -375,6 +375,7 @@ class CVMFSCatalog(object):
     self.__downloader = CVMFSDownloader(config)
     self.__cat_path = cat_path
     self.__cat_hash = cat_hash
+    self.__blacklist_paths = config.get_blacklist()
     self.__db_conn = None
     self.__changes = 0 # Number of changes (for tracking autocommit)
     self.__autocommit = autocommit
@@ -387,6 +388,12 @@ class CVMFSCatalog(object):
   def __del__(self):
     pass
     #self.__close_db() # We can't close here as deleteion is in any thread!
+
+  def __valid_path(self, pathname):
+    for entry in self.__blacklist_paths:
+      if fnmatch.fnmatch(pathname, entry):
+        return False
+    return True
 
   def __open_db(self):
     """ Opens the DB of the current specified cat_hash. """

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -502,11 +502,15 @@ class CVMFSCatalog(object):
       self.__done_eval = True
       return False
     # Check how many files are set as seen:
-    cur = self.__db_conn.cursor()
-    sql = "SELECT COUNT(rowid) FROM catalog WHERE seen != 1"
-    cur.execute(sql)
-    res = cur.fetchone()
-    cur.close()
+    try:
+        cur = self.__db_conn.cursor()
+        sql = "SELECT COUNT(rowid) FROM catalog WHERE seen != 1"
+        cur.execute(sql)
+        res = cur.fetchone()
+        cur.close()
+    except sqlite3.OperationalError, oe:
+        self.__config.get_log().error("Failed to query catalog: %s", str(oe))
+        return True
     # Check the number of objects left to process
     self.__is_done = (res[0] <= 1)
     self.__done_eval = True

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -1024,6 +1024,7 @@ class UNCVMFSConfig(object):
     self.__db_path = None
     self.__data_path = None
     self.__squashfs_path = None
+    self.__download_threads = 1
     self.__store_path = None
     self.__proxy = ""
     self.__urls = None
@@ -1055,6 +1056,8 @@ class UNCVMFSConfig(object):
       elif opt == 'squashfs_path':
         tmp_path = conf.get(repo, "squashfs_path")
         self.__squashfs_path = os.path.normpath(tmp_path)
+      elif opt == 'download_threads':
+        self.__download_threads = int(conf.get(repo, 'download_threads'))
       elif opt == 'store_path':
         tmp_path = conf.get(repo, "store_path")
         self.__store_path = os.path.normpath(tmp_path)
@@ -1135,6 +1138,12 @@ class UNCVMFSConfig(object):
     """ Returns the desired output path for the squashfs file.
     """
     return self.__squashfs_path
+
+  def get_download_threads(self):
+    """ Returns the default number of threads as set by the config file.
+        If not specified, return 1
+    """
+    return self.__download_threads
 
   def get_proxy(self):
     """ Returns the proxy server the user specified. """

--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -664,6 +664,8 @@ class CVMFSCatalog(object):
     # Handle the recursion
     for dir_name, _, _ in dirs:
       dir_path = os.path.join(real_path, dir_name)
+      if not self.__valid_path(dir_path):
+        continue
       if dir_path in sub_cats:
         # This dir is a mountpoint, traverse down
         self.__config.get_log().debug("Walking into '%s'..." % dir_path)

--- a/uncvmfs
+++ b/uncvmfs
@@ -11,6 +11,7 @@ import stat
 import getopt
 import shutil
 import logging
+import tempfile
 from UNCVMFSLib import UNCVMFS_VERSION
 from UNCVMFSLib import CVMFSManager, UNCVMFSDownloadPool, UNCVMFSConfig
 

--- a/uncvmfs
+++ b/uncvmfs
@@ -189,6 +189,32 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
   complete_files(pool)
   pool.shutdown()
 
+  squashfs_path = conf.get_squashfs_path()
+  if squashfs_path:
+    path_re = re.compile(r"[-,_./A-Za-z0-9]+")
+    if not path_re.match(data_path):
+      print "Refusing to write to unsanitized data path: %s" % data_path
+      sys.exit(1)
+    if not path_re.match(squashfs_path):
+      print "Refusing to write to unsanitized squashfs path: %s" % squashfs_path
+      sys.exit(1)
+    cmd = os.system("mksquashfs %s %s" % (data_path, squashfs_path))
+    if not os.isatty(1):
+      cmd += " -no-progress"
+    blacklist = conf.get_blacklist()
+    name = None
+    if blacklist:
+      fd, name = tempfile.mkstemp()
+      with os.fdopen(fd, "w") as fp:
+        fp.write("\n".join(blacklist))
+      cmd += " -ef %s" % name
+    result = os.system(cmd)
+    if name:
+      os.unlink(name)
+    if result:
+      sys.exit(result)
+    # TODO: now, stageout squashfs file.
+
 def usage(err_str):
   """ Print the command usage & exit. """
   if err_str:

--- a/uncvmfs
+++ b/uncvmfs
@@ -5,6 +5,7 @@ Copyright 2014, Imperial College HEP Group
 """
 
 import os
+import re
 import sys
 import stat
 import getopt
@@ -12,7 +13,6 @@ import shutil
 import logging
 from UNCVMFSLib import UNCVMFS_VERSION
 from UNCVMFSLib import CVMFSManager, UNCVMFSDownloadPool, UNCVMFSConfig
-
 
 def __tidy_object(full_path, throw=False):
   """ Deletes an object in the given path.
@@ -207,7 +207,7 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
       fd, name = tempfile.mkstemp()
       with os.fdopen(fd, "w") as fp:
         fp.write("\n".join(blacklist))
-      cmd += " -ef %s" % name
+      cmd += " -wildcards -ef %s" % name
     result = os.system(cmd)
     if name:
       os.unlink(name)
@@ -234,7 +234,7 @@ def main():
   # Application options
   cat_only = False
   no_update = False
-  threads = 1
+  threads = -1
   verbose = 0
   conf_name = None
   repo_name = None
@@ -283,6 +283,8 @@ def main():
     sys.exit(1)
   # Everything OK, run the real work
   logging.debug("Processing updates...")
+  if threads < 0:
+    threads = conf.get_download_threads()
   do_uncvmfs(conf, cat_only, no_update, threads)
 
 if __name__ == '__main__':

--- a/uncvmfs
+++ b/uncvmfs
@@ -199,6 +199,8 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
     if not path_re.match(squashfs_path):
       print "Refusing to write to unsanitized squashfs path: %s" % squashfs_path
       sys.exit(1)
+    squashfs_final = squashfs_path
+    squashfs_path += ".new"
     cmd = "mksquashfs %s %s" % (data_path, squashfs_path)
     if not os.isatty(1):
       cmd += " -no-progress"
@@ -206,15 +208,16 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
     name = None
     if blacklist:
       fd, name = tempfile.mkstemp()
+      prefix_re = re.compile("(^/+)")
       with os.fdopen(fd, "w") as fp:
-        fp.write("\n".join(blacklist))
+        fp.write("\n".join([prefix_re.sub("", i) for i in blacklist]))
       cmd += " -wildcards -ef %s" % name
     result = os.system(cmd)
     if name:
       os.unlink(name)
     if result:
       sys.exit(result)
-    # TODO: now, stageout squashfs file.
+    os.rename(squashfs_path, squashfs_final)
 
 def usage(err_str):
   """ Print the command usage & exit. """

--- a/uncvmfs
+++ b/uncvmfs
@@ -198,7 +198,7 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
     if not path_re.match(squashfs_path):
       print "Refusing to write to unsanitized squashfs path: %s" % squashfs_path
       sys.exit(1)
-    cmd = os.system("mksquashfs %s %s" % (data_path, squashfs_path))
+    cmd = "mksquashfs %s %s" % (data_path, squashfs_path)
     if not os.isatty(1):
       cmd += " -no-progress"
     blacklist = conf.get_blacklist()

--- a/uncvmfs.conf
+++ b/uncvmfs.conf
@@ -9,6 +9,10 @@ urls = http://cvmfs-stratum-one.cern.ch/opt/cms;http://cernvmfs.gridpp.rl.ac.uk/
 keys = /etc/uncvmfs/keys/cern.ch.pub;/etc/uncvmfs/keys/cern-it1.cern.ch.pub;/etc/uncvmfs/keys/cern-it2.cern.ch.pub;/etc/uncvmfs/keys/cern-it3.cern.ch.pub
 #proxy = http://local.squid:3128
 #env = CMS_LOCAL_SITE=/some/path/to/siteconf
+# Uncomment the squashfs_path to have mksquashfs be run as the last step of the synchronization.
+#squashfs_path = /cvmfs/cms.cern.ch.squashfs
+# Uncomment the following to stageout the squashfs image
+#squashfs_url = file:///var/lib/www/html/cms.cern.ch.squashfs
 
 [mice]
 db_path = /var/lib/cvmfs/mice_db

--- a/uncvmfs.service
+++ b/uncvmfs.service
@@ -1,0 +1,18 @@
+
+[Unit]
+Description=uncvmfs repo update service
+Documentation=https://github.com/ic-hep/uncvmfs/
+After=network.target
+Wants=network.target
+
+[Service]
+ExecStart=/usr/bin/uncvmfs /etc/uncvmfs/uncvmfs.conf %i
+WorkingDirectory=/var/lib/uncvmfs
+RestartSec=30min
+Restart=always
+User=uncvmfs
+Nice=19
+
+[Install]
+WantedBy=multi-user.target
+

--- a/uncvmfs.service
+++ b/uncvmfs.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/uncvmfs /etc/uncvmfs/uncvmfs.conf %i
 WorkingDirectory=/var/lib/uncvmfs
 RestartSec=30min
 Restart=always
-User=uncvmfs
+User=cvmfs
 Nice=19
 
 [Install]

--- a/uncvmfs.spec
+++ b/uncvmfs.spec
@@ -26,6 +26,7 @@ BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 BuildRequires:  python python-devel openssl-devel
 Requires:       python openssl
+Requires:       squashfs-tools
 Requires(pre):  shadow-utils
 
 %if %systemd

--- a/uncvmfs.spec
+++ b/uncvmfs.spec
@@ -12,6 +12,10 @@ Summary:        A tool for unpacking CVMFS repos
 Group:          Applications/Internet
 License:        GPLv2
 URL:            http://www.hep.ph.ic.ac.uk
+# For github-based releases, download from
+# https://github.com/ic-hep/uncvmfs/archive/%{version}.tar.gz
+# For git snapshots, try:
+# git archive --prefix=%{name}-%{version}/ %{gitrev} | bzip2 > %{name}-%{version}-%{gitrev}.tar.bz2
 Source0:        http://fake.url/uncvmfs-%{version}.tar.bz2
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
@@ -44,10 +48,10 @@ install -m 0755 extra/uncvmfs_cron %{buildroot}/%{_bindir}/uncvmfs_cron
 ## Conf & Keys
 install -d %{buildroot}/%{_sysconfdir}/uncvmfs/keys
 install -m 0644 uncvmfs.conf %{buildroot}/%{_sysconfdir}/uncvmfs/uncvmfs.conf
-install -m 0644 extra/keys/* \
-                %{buildroot}/%{_sysconfdir}/uncvmfs/keys
+#install -m 0644 extra/keys/* \
+#                %{buildroot}/%{_sysconfdir}/uncvmfs/keys
 ## "Home" directory
-install -d %{buildroot}/%{_localstatedir}/lib/cvmfs
+install -d %{buildroot}/%{_localstatedir}/lib/uncvmfs
 
 %clean
 rm -Rf %{buildroot}
@@ -60,19 +64,19 @@ rm -Rf %{buildroot}
 %dir %{_sysconfdir}/uncvmfs
 %config(noreplace) %{_sysconfdir}/uncvmfs/uncvmfs.conf
 %dir %{_sysconfdir}/uncvmfs/keys
-%config %{_sysconfdir}/uncvmfs/keys/*
+#%config %{_sysconfdir}/uncvmfs/keys/*
 %config(noreplace) %{_sysconfdir}/cron.d/uncvmfs.cron
 %config(noreplace) %{_sysconfdir}/sysconfig/uncvmfs
 %{python2_sitearch}/CVMFSSig.so
 %{python2_sitearch}/UNCVMFSLib.py*
-%{python2_sitearch}/%{name}-%{version}-py2.6.egg-info
-%{_localstatedir}/lib/cvmfs
+%{python2_sitearch}/%{name}-%{version}-py2.*.egg-info
+%{_localstatedir}/lib/uncvmfs
 %doc README
 
 %pre
 getent group cvmfs >/dev/null || groupadd -r cvmfs
 getent passwd cvmfs >/dev/null || \
-    useradd -r -g cvmfs -d %{_localstatedir}/lib/cvmfs -s /sbin/nologin \
+    useradd -r -g cvmfs -d %{_localstatedir}/lib/uncvmfs -s /sbin/nologin \
     -c "CVMFS tools" cvmfs
 exit 0
 


### PR DESCRIPTION
When synchronizing, significant time can be realized by skipping paths that are known to be not necessary.  This implements a blacklist mechanism to allow you to strip out quite a few files from the repo.

This also integrates `mksquashfs` into the CLI, providing a way to generate _disk images_ instead of directories from CVMFS.  This should be helpful in the case of HPC sites where inodes are in limited supply.

Finally, a `systemd` service is provided; this provides a better user experience on RHEL7.  With `systemd`, the system ensures only one update is running at a time and can trigger new runs at a fixed time after the previous run completed.
