### PR TITLE
allow to customize building the squashfs image

### DIFF
--- a/UNCVMFSLib.py
+++ b/UNCVMFSLib.py
@@ -1024,6 +1024,8 @@ class UNCVMFSConfig(object):
     self.__db_path = None
     self.__data_path = None
     self.__squashfs_path = None
+    self.__squashfs_prefix = "/"
+    self.__squashfs_merge = []
     self.__download_threads = 1
     self.__store_path = None
     self.__proxy = ""
@@ -1056,6 +1058,10 @@ class UNCVMFSConfig(object):
       elif opt == 'squashfs_path':
         tmp_path = conf.get(repo, "squashfs_path")
         self.__squashfs_path = os.path.normpath(tmp_path)
+      elif opt == 'squashfs_prefix':
+        self.__squashfs_prefix = os.path.normpath(conf.get(repo, "squashfs_prefix"))
+      elif opt == 'squashfs_merge':
+        self.__squashfs_merge = get_array_opt(conf.get(repo, "squashfs_merge"))
       elif opt == 'download_threads':
         self.__download_threads = int(conf.get(repo, 'download_threads'))
       elif opt == 'store_path':
@@ -1138,6 +1144,20 @@ class UNCVMFSConfig(object):
     """ Returns the desired output path for the squashfs file.
     """
     return self.__squashfs_path
+
+  def get_squashfs_prefix(self):
+    """ Returns the desired output path for the CVMFS directory
+        within the squashfs image.  For example, setting squashfs_prefix
+        to /cvmfs/cms.cern.ch will result in CVMFS files appearing
+        inside that directory
+    """
+    return self.__squashfs_prefix
+
+  def get_squashfs_merge(self):
+    """ Returns a list of local directories to merge into the output squashfs
+        image.
+    """
+    return self.__squashfs_merge
 
   def get_download_threads(self):
     """ Returns the default number of threads as set by the config file.

--- a/uncvmfs
+++ b/uncvmfs
@@ -158,6 +158,7 @@ def do_deletes(cat_obj, path, dirs, files, links):
 
 def do_uncvmfs(conf, cat_only, no_update, num_threads):
   """ The main application logic. """
+  logging.info("Starting application.")
   _, data_path, _ = conf.get_paths()
   manager = CVMFSManager(conf)
   # Update the catalog
@@ -189,32 +190,70 @@ def do_uncvmfs(conf, cat_only, no_update, num_threads):
   pool.wait()
   complete_files(pool)
   pool.shutdown()
+  logging.info("Download finished.")
 
   squashfs_path = conf.get_squashfs_path()
+  squashfs_prefix = conf.get_squashfs_prefix()
+  while squashfs_prefix.endswith("/"):
+    squashfs_prefix = squashfs_prefix[:-1]
+  squashfs_data_path = data_path
+  if not squashfs_data_path.endswith(squashfs_prefix):
+    logging.critical("Data path (%s) must end with squashfs prefix (%s)", data_path, squashfs_prefix)
+    sys.exit(1)
+  if len(squashfs_prefix) > 0:
+    squashfs_data_path = squashfs_data_path[:-len(squashfs_prefix)]
+  squashfs_merge_list = conf.get_squashfs_merge()
   if squashfs_path:
     path_re = re.compile(r"[-,_./A-Za-z0-9]+")
-    if not path_re.match(data_path):
-      print "Refusing to write to unsanitized data path: %s" % data_path
+    if not path_re.match(squashfs_data_path):
+      logging.critical("Refusing to write to unsanitized data path: %s", squashfs_data_path)
       sys.exit(1)
     if not path_re.match(squashfs_path):
-      print "Refusing to write to unsanitized squashfs path: %s" % squashfs_path
+      logging.critical("Refusing to write to unsanitized squashfs path: %s", squashfs_path)
       sys.exit(1)
+    for path in squashfs_merge_list:
+      if not path_re.match(path):
+        logging.critical("Refusing to write to unsanitized squashfs merge path: %s", path)
+        sys.exit(1)
     squashfs_final = squashfs_path
     squashfs_path += ".new"
-    cmd = "mksquashfs %s %s" % (data_path, squashfs_path)
+    cmd = "mksquashfs %s %s" % (squashfs_data_path, squashfs_path)
     if not os.isatty(1):
       cmd += " -no-progress"
     blacklist = conf.get_blacklist()
     name = None
-    if blacklist:
+    if blacklist or squashfs_prefix:
       fd, name = tempfile.mkstemp()
       prefix_re = re.compile("(^/+)")
-      with os.fdopen(fd, "w") as fp:
-        fp.write("\n".join([prefix_re.sub("", i) for i in blacklist]))
-      cmd += " -wildcards -ef %s" % name
+      prefix = squashfs_prefix + "/"
+      while prefix.startswith("/"):
+        prefix = prefix[1:]
+      split_re = re.compile("/+")
+      prefix_subpaths = split_re.split(prefix)
+      exclude_files = []
+      for idx in range(len(prefix_subpaths)-1):
+        current_prefix = "/".join(prefix_subpaths[:idx])
+        contents = os.listdir(os.path.join(squashfs_data_path, current_prefix))
+        exclude_files += [os.path.join(current_prefix, i) for i in contents if i != prefix_subpaths[idx]]
+      if exclude_files or blacklist:
+        with os.fdopen(fd, "w") as fp:
+           all_files = exclude_files + [prefix_re.sub("", prefix + i) for i in blacklist]
+           logging.debug("Exclude files:\n%s","\n".join(all_files))
+           fp.write("\n".join(all_files))
+        cmd += " -wildcards -ef %s" % name
+    logging.info("Executing command %s", cmd)
     result = os.system(cmd)
+    logging.info("Commmand execution finished.")
     if name:
       os.unlink(name)
+    for squashfs_merge in squashfs_merge_list:
+      if not result:
+        cmd = "mksquashfs %s %s" % (squashfs_merge, squashfs_path)
+        if not os.isatty(1):
+          cmd += " -no-progress"
+          logging.info("Executing command %s", cmd)
+          result = os.system(cmd)
+          logging.info("Commmand execution finished.")
     if result:
       sys.exit(result)
     os.rename(squashfs_path, squashfs_final)
@@ -296,4 +335,3 @@ if __name__ == '__main__':
     main()
   except KeyboardInterrupt:
     sys.exit(0)
-

--- a/uncvmfs.conf
+++ b/uncvmfs.conf
@@ -11,8 +11,13 @@ keys = /etc/uncvmfs/keys/cern.ch.pub;/etc/uncvmfs/keys/cern-it1.cern.ch.pub;/etc
 #env = CMS_LOCAL_SITE=/some/path/to/siteconf
 # Uncomment the squashfs_path to have mksquashfs be run as the last step of the synchronization.
 #squashfs_path = /cvmfs/cms.cern.ch.squashfs
-# Uncomment the following to stageout the squashfs image
-#squashfs_url = file:///var/lib/www/html/cms.cern.ch.squashfs
+# Uncomment for blacklist for mksquashfs (to limit what is put into the squashfs image)
+#blacklist_paths = path4;path5*;path6*
+# Uncomment to put the cvmfs clone under a prefix in the squashfs image (emulating a mount point)
+#squashfs_prefix = /cvmfs/cms.cern.ch
+# Uncomment to merge one or more directories into the squashfs image
+#squashfs_merge = /local/dir1;/local/dir2
+download_threads = 8
 
 [mice]
 db_path = /var/lib/cvmfs/mice_db


### PR DESCRIPTION
Allow to configure a prefix for the cvmfs copy in the squashfs image (to emulate a default mount point) and also to merge one or more additional directories into the image. The latter is useful to create a OS base image plus cvmfs repository. Adjust the logging options to have more useful output with the single -v option. Change some of the print statements to more approprate logging statements.