### PR TITLE
Avoid use of production stratum 1s, proxies, and old url paths

### DIFF
--- a/uncvmfs.conf
+++ b/uncvmfs.conf
@@ -5,7 +5,7 @@
 db_path = /var/lib/cvmfs/cms_db
 data_path = /cvmfs/cms.cern.ch
 store_path = /cvmfs/data/cms
-urls = http://cvmfs-stratum-one.cern.ch/opt/cms;http://cernvmfs.gridpp.rl.ac.uk/opt/cms;http://cvmfs.racf.bnl.gov/opt/cms;http://cvmfs.fnal.gov/opt/cms
+urls = http://hcc-cvmfs.unl.edu:8000/cvmfs/cms.cern.ch
 keys = /etc/uncvmfs/keys/cern.ch.pub;/etc/uncvmfs/keys/cern-it1.cern.ch.pub;/etc/uncvmfs/keys/cern-it2.cern.ch.pub;/etc/uncvmfs/keys/cern-it3.cern.ch.pub
 #proxy = http://local.squid:3128
 #env = CMS_LOCAL_SITE=/some/path/to/siteconf
@@ -31,7 +31,7 @@ keys = /etc/uncvmfs/keys/gridpp.ac.uk.pub
 db_path = /var/lib/cvmfs/lhcb_db
 data_path = /cvmfs/lhcb.cern.ch
 store_path = /cvmfs/data/lhcb
-urls = http://cvmfs-stratum-one.cern.ch/opt/lhcb;http://cernvmfs.gridpp.rl.ac.uk/opt/lhcb;http://cvmfs.racf.bnl.gov/opt/lhcb;http://cvmfs.fnal.gov/opt/lhcb
+urls = http://hcc-cvmfs.unl.edu:8000/cvmfs/lhcb.cern.ch
 keys = /etc/uncvmfs/keys/cern.ch.pub;/etc/uncvmfs/keys/cern-it1.cern.ch.pub;/etc/uncvmfs/keys/cern-it2.cern.ch.pub;/etc/uncvmfs/keys/cern-it3.cern.ch.pub
 #proxy = http://local.squid:3128
 

--- a/uncvmfs.conf
+++ b/uncvmfs.conf
@@ -1,5 +1,7 @@
 # Example unCVMFS config file
 # See README for details of parameters
+# Avoid reading from production stratum 1s and proxy squids because
+#   that can interfere with caching for ordinary client traffic
 
 [cms]
 db_path = /var/lib/cvmfs/cms_db


### PR DESCRIPTION
Avoid reading entire repositories from production stratum 1s because it can interfere with caching used by ordinary clients.  The hcc-cvmfs.unl.edu stratum 1 owned by @bbockelm is a better default source for cern.ch and opensciencegrid.org repositories.  I don't believe there is an equivalent for egi.eu or gridpp.ac.uk repositories at this time.   Using site proxy squids can also interfere with caching for ordinary client traffic there, so avoid that too.

Also, /opt/repo is an old style path that has been replaced with /cvmfs/repo.domain.name, so avoid the old path style.  Port 8000 is a better default stratum 1 port.